### PR TITLE
fix: harden GithubEvents against null repo names (client-side crash)

### DIFF
--- a/.stokd/meta/SC_AXIOMS.md
+++ b/.stokd/meta/SC_AXIOMS.md
@@ -166,6 +166,18 @@ The effective MongoDB database name MUST remain `brianstoker-production` (prod) 
 
 ---
 
+## AX-REPO-BOOKING-CALENDAR-MODAL: The /book-time "Meet" surface is a next-available rolling grid with a cached, modal booking form
+The booking UI rendered by `@stoked-ui/common`'s `CalendarBooking` (source at `/opt/worktrees/stoked-ui/stoked-ui-main/packages/sui-common/src/CalendarBooking`, consumed via the `file:` build dep — never pinned, rebuilt locally and never pushed without intent to publish) MUST: (1) render exactly **5 business-day columns** beginning at the **next available booking day** — today when it is a weekday and the business-timezone (`America/Chicago`) wall-clock now is before the last 5:30 PM slot start, otherwise the next weekday; Saturdays and Sundays are never shown as columns; (2) default-select **today** in the Sunday→Saturday mini-calendar, whose Saturday/Sunday columns are visually shaded; (3) cache `/api/calendar/availability` responses in `sessionStorage` under the `sui-availability:` key prefix with a **30-minute TTL**, reusing the cache on re-entry instead of re-querying; (4) present the booking form as a **MUI Dialog modal** (`data-testid="booking-form"`) triggered by a slot click, requiring Name/Email/Phone/Reason and accepting an `inviteEmails` chip field POSTed to `/api/calendar/book`; (5) be **responsive** — the mini-calendar and week grid stack below the `sm` breakpoint, the grid is horizontally scrollable, and the modal is full-screen on `xs`. Slot instants stay `America/Chicago`-pinned per [[ax-repo-booking-tz-safe-slots]]; `pages/api/calendar/book.ts` MUST require `reason` and add `inviteEmails` as additional Google Calendar attendees.
+
+### Acceptance Checks
+- `rg -n "firstAvailableDateStr|buildWindowDates|LAST_SLOT_MINUTES" /opt/worktrees/stoked-ui/stoked-ui-main/packages/sui-common/src/CalendarBooking/CalendarBooking.tsx` shows the next-available 5-business-day window logic; e2e asserts exactly 5 day-column headers and no Sat/Sun.
+- `rg -n "sui-availability:|CACHE_TTL_MS" /opt/worktrees/stoked-ui/stoked-ui-main/packages/sui-common/src/CalendarBooking/CalendarBooking.tsx` shows the 30-minute sessionStorage cache; e2e asserts no second availability request within the TTL.
+- `rg -n "Dialog|inviteEmails|formData.reason" /opt/worktrees/stoked-ui/stoked-ui-main/packages/sui-common/src/CalendarBooking/CalendarBooking.tsx` shows the modal form, reason-required submit gate, and invite chips; `rg -n "reason|inviteEmails|attendees" pages/api/calendar/book.ts` shows the server contract.
+- `rg -n "Meet" src/components/header/HeaderNavBar.tsx src/components/header/HeaderNavDropdown.tsx pages/book-time.tsx` shows the renamed nav item, active-route indicator, and page title.
+- `pnpm typescript` passes, the sui-common jest suite passes, and `npx playwright test e2e/book-time.spec.ts` passes against dev on 5040.
+
+---
+
 <!--
 stokd-axiom-candidate (RESOLVED 2026-06-09)
 note: The `scripts/.axioms.md` AX-MOD-SCRIPTS-008 / AWS-profile reconciliation candidate ("reconcile to a single profile name and promote the global axiom") is now satisfied: AX-REPO-AWS-PROFILE-DISCIPLINE above was corrected from `stoked` to `stokd-cloud` (account 167217327520) in this refresh. Kept as a marker so future refreshes do not re-flag it.

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,7 +18,7 @@
       "type": "chrome",
       "request": "launch",
       "url": "http://localhost:5041"
-5041    },
+    },
     {
       "name": "Next.js: debug full stack",
       "type": "node",

--- a/=
+++ b/=
@@ -1,1 +1,0 @@
-src/components/CalendarBooking/CalendarBooking.tsx:0

--- a/e2e/book-time.spec.ts
+++ b/e2e/book-time.spec.ts
@@ -56,8 +56,10 @@ test.describe('Book Time page — layout', () => {
 
   test('today\'s column cells are highlighted, other columns are not', async ({ page }) => {
     const now = new Date();
-    test.skip(isWeekend(now), 'Today is a weekend — not shown in the Mon–Fri grid');
+    test.skip(isWeekend(now), 'Today is a weekend — not shown in the booking grid');
     await gotoBookTime(page);
+    const todayColumn = page.locator(`[data-day-column="${localDateStr(now)}"]`);
+    test.skip(await todayColumn.count() === 0, 'Today is past the last slot — not in the next-available window');
     const todayCells = page.locator(`[data-day-column="${localDateStr(now)}"] [data-today="true"]`);
     expect(await todayCells.count()).toBeGreaterThan(0);
     // No highlighted cells outside today's column
@@ -84,9 +86,8 @@ test.describe('Book Time page — layout', () => {
     await page.waitForTimeout(3000); // let availability load
 
     // The first slot of today (10:30 AM) has passed; it must not be a clickable time-slot.
-    const dayIndex = (now.getDay() + 6) % 7; // Mon=0 … Fri=4
-    const columns = page.locator('[data-testid="week-grid"] [data-day-column]');
-    const todayColumn = columns.nth(dayIndex);
+    const todayColumn = page.locator(`[data-day-column="${localDateStr(now)}"]`);
+    test.skip(await todayColumn.count() === 0, 'Today is past the last slot — not in the next-available window');
     const firstCell = todayColumn.locator('[data-testid="time-slot"], [data-testid="day-unavailable"]').first();
     await expect(firstCell).toHaveAttribute('data-testid', 'day-unavailable');
   });
@@ -357,7 +358,7 @@ test.describe('Book Time page — UI with real API', () => {
     await expect(page.getByTestId('duration-display')).toContainText('45');
   });
 
-  test('submit button disabled until name, email, phone filled', async ({ page }) => {
+  test('submit button disabled until name, email, phone, reason filled', async ({ page }) => {
     await gotoBookTime(page);
     const date = nextWeekday();
     const d = parseInt(date.split('-')[2], 10);
@@ -378,6 +379,10 @@ test.describe('Book Time page — UI with real API', () => {
     await expect(submit).toBeDisabled();
 
     await page.locator('input[name="phone"]').fill('555-1234');
+    // Reason is now required — still disabled without it
+    await expect(submit).toBeDisabled();
+
+    await page.locator('textarea[name="reason"]').first().fill('Discuss a project');
     await expect(submit).not.toBeDisabled();
   });
 
@@ -396,10 +401,96 @@ test.describe('Book Time page — UI with real API', () => {
     await page.locator('input[name="email"]').fill('brian@stokd.cloud');
     await page.locator('input[name="phone"]').fill('555-0000');
     await page.locator('input[name="company"]').fill('Stoked');
-    await page.locator('input[name="reason"]').fill('Automated e2e test — safe to delete');
+    await page.locator('textarea[name="reason"]').first().fill('Automated e2e test — safe to delete');
 
     await page.getByRole('button', { name: /book appointment/i }).click();
 
     await expect(page.getByTestId('booking-success')).toBeVisible({ timeout: 15000 });
+  });
+});
+
+// ── New "Meet" behaviors ──────────────────────────────────────────────────────
+
+test.describe('Book Time page — Meet title & active nav', () => {
+  test('page title and heading are "Meet" and the nav item is active', async ({ page }) => {
+    await gotoBookTime(page);
+    await expect(page).toHaveTitle(/Meet/);
+    await expect(page.getByRole('heading', { level: 1, name: 'Meet' })).toBeVisible();
+    // Desktop nav exposes the active route via aria-current
+    const active = page.locator('nav a[aria-current="page"]');
+    if (await active.count() > 0) {
+      await expect(active.first()).toHaveText('Meet');
+    }
+  });
+});
+
+test.describe('Book Time page — default selection & window', () => {
+  test('today is selected in the mini calendar on load', async ({ page }) => {
+    await gotoBookTime(page);
+    const selectedCells = page.locator('[data-testid="mini-cal-cell"][data-selected="true"]');
+    await expect(selectedCells).toHaveCount(1);
+  });
+
+  test('first day column is a weekday on or after today', async ({ page }) => {
+    await gotoBookTime(page);
+    const firstCol = page.locator('[data-day-column]').first();
+    const dateStr = await firstCol.getAttribute('data-day-column');
+    expect(dateStr).toBeTruthy();
+    const [y, m, d] = dateStr!.split('-').map(Number);
+    const dow = new Date(Date.UTC(y, m - 1, d)).getUTCDay();
+    expect(dow === 0 || dow === 6).toBe(false);
+  });
+});
+
+test.describe('Book Time page — modal booking form', () => {
+  test('booking form is a modal (in a dialog) with an invite-others chip field', async ({ page }) => {
+    await gotoBookTime(page);
+    const date = nextWeekday();
+    const d = parseInt(date.split('-')[2], 10);
+    await page.getByTestId('mini-calendar').getByText(String(d)).click();
+    await page.waitForTimeout(3000);
+
+    const slot = page.getByTestId('time-slot').first();
+    if (await slot.count() === 0) { test.skip(true, 'No slots'); return; }
+    await slot.click();
+
+    // The form lives inside a MUI Dialog
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByTestId('booking-form')).toBeVisible();
+
+    // Add an invitee → chip appears
+    const invite = page.getByTestId('invite-input');
+    await invite.fill('guest@example.com');
+    await invite.press('Enter');
+    await expect(dialog.getByText('guest@example.com')).toBeVisible();
+
+    // "Change time" closes the modal
+    await page.getByTestId('change-time').click();
+    await expect(page.getByRole('dialog')).toHaveCount(0);
+  });
+});
+
+test.describe('Book Time page — availability cache', () => {
+  test('returning to the page within the TTL does not re-query availability', async ({ page }) => {
+    const availabilityRequests: string[] = [];
+    page.on('request', (req) => {
+      if (req.url().includes('/api/calendar/availability')) {
+        availabilityRequests.push(req.url());
+      }
+    });
+
+    await gotoBookTime(page);
+    await page.waitForTimeout(2000);
+    expect(availabilityRequests.length).toBeGreaterThan(0);
+    const firstCount = availabilityRequests.length;
+
+    // Leave the page, then return within the cache TTL (sessionStorage persists)
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+    await gotoBookTime(page);
+    await page.waitForTimeout(2000);
+
+    expect(availabilityRequests.length).toBe(firstCount);
   });
 });

--- a/e2e/github-events-null-repo.spec.ts
+++ b/e2e/github-events-null-repo.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Regression: a null entry in the /api/github/filters `repositories` array must
+ * not crash the client. Previously GithubEvents' `mobileRepoGroups` useMemo did
+ * `repositories.map(repoName => repoName.split('/'))` with no guard, so a null
+ * repo name threw "TypeError: Cannot read properties of null (reading 'split')"
+ * and took down the whole page via the React error boundary.
+ *
+ * The /work page mounts <GithubEvents /> directly, so it is the tightest repro.
+ */
+test('GithubEvents tolerates a null repo from the filters API', async ({ page }) => {
+  await page.route('**/api/github/filters', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        // The offending shape: a null slipped into the repo list.
+        repositories: ['brian-stoker/v2.brianstoker.com', null],
+        actionTypes: [],
+        repositoryStats: [
+          {
+            name: 'brian-stoker/v2.brianstoker.com',
+            count: 1,
+            lastEventDate: '2026-01-01T00:00:00Z',
+            recentTypes: ['PushEvent'],
+          },
+        ],
+      }),
+    });
+  });
+
+  // Keep the events feed deterministic; the crash is independent of it.
+  await page.route('**/api/github/events**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ events: [], entries: [], totalCount: 0 }),
+    });
+  });
+
+  const crashes: string[] = [];
+  const isSplitCrash = (msg: string) =>
+    /Cannot read properties of null \(reading 'split'\)/.test(msg);
+  page.on('pageerror', (err) => {
+    if (isSplitCrash(String(err))) crashes.push(String(err));
+  });
+  page.on('console', (msg) => {
+    if (msg.type() === 'error' && isSplitCrash(msg.text())) crashes.push(msg.text());
+  });
+
+  await page.goto('/work', { waitUntil: 'networkidle' });
+  // Give the filters fetch + useMemo a beat to run.
+  await page.waitForTimeout(1500);
+
+  expect(
+    crashes,
+    `client threw the null-repo split crash:\n${crashes.join('\n')}`,
+  ).toHaveLength(0);
+});

--- a/pages/api/calendar/book.ts
+++ b/pages/api/calendar/book.ts
@@ -10,6 +10,7 @@ interface BookingRequest {
   reason?: string;
   startTime?: string;
   durationMinutes?: number;
+  inviteEmails?: string[];
 }
 
 type ResponseData = {
@@ -26,12 +27,21 @@ export default async function handler(
     return res.status(405).json({ error: 'Method not allowed' });
   }
 
-  const { name, email, phone, company, reason, startTime, durationMinutes } =
+  const { name, email, phone, company, reason, startTime, durationMinutes, inviteEmails } =
     req.body as BookingRequest;
 
   // Validate required fields
-  if (!name || !email || !phone) {
-    return res.status(400).json({ error: 'Missing required fields: name, email, phone' });
+  if (!name || !email || !phone || !reason) {
+    return res.status(400).json({ error: 'Missing required fields: name, email, phone, reason' });
+  }
+
+  // Validate any invitee emails before building the event
+  const emailRe = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  const invitees = Array.isArray(inviteEmails)
+    ? inviteEmails.map((e) => String(e).trim()).filter(Boolean)
+    : [];
+  if (invitees.some((e) => !emailRe.test(e))) {
+    return res.status(400).json({ error: 'One or more invite emails are invalid' });
   }
 
   if (!startTime || typeof startTime !== 'string') {
@@ -92,6 +102,9 @@ export default async function handler(
             email: email!,
             displayName: name || undefined,
           },
+          ...invitees
+            .filter((e) => e.toLowerCase() !== email!.toLowerCase())
+            .map((e) => ({ email: e })),
         ],
       },
     });

--- a/pages/book-time.tsx
+++ b/pages/book-time.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
+import Head from '../src/modules/components/Head';
 import { HomeView } from './index';
 import { CalendarBooking } from '@stoked-ui/common';
 
@@ -22,8 +23,16 @@ function BookTimeView() {
         width: '100%',
         pt: 2,
         pb: 6,
+        px: { xs: 2, sm: 3 },
       }}
     >
+      <Typography
+        component="h1"
+        variant="h3"
+        sx={{ fontWeight: 800, mb: { xs: 3, sm: 4 }, alignSelf: { xs: 'flex-start', md: 'center' } }}
+      >
+        Meet
+      </Typography>
 
       <CalendarBooking
         apiBaseUrl=""
@@ -35,5 +44,10 @@ function BookTimeView() {
 }
 
 export default function BookTime() {
-  return <HomeView HomeMain={BookTimeView} noSection />;
+  return (
+    <React.Fragment>
+      <Head title="Meet" description="Book time with Brian Stoker" />
+      <HomeView HomeMain={BookTimeView} noSection />
+    </React.Fragment>
+  );
 }

--- a/public/feed/.plan/rss.xml
+++ b/public/feed/.plan/rss.xml
@@ -4,7 +4,7 @@
         <title>bstoked.plan</title>
         <link>brian.stokd.cloud/blog</link>
         <description>Follow the SUI .plan to learn about new product features, latest advancements in UI development, and business initiatives.</description>
-        <lastBuildDate>Thu, 11 Jun 2026 23:10:47 GMT</lastBuildDate>
+        <lastBuildDate>Fri, 12 Jun 2026 11:58:21 GMT</lastBuildDate>
         <docs>https://validator.w3.org/feed/docs/rss2.html</docs>
         <generator>https://github.com/jpmonette/feed</generator>
         <language>en</language>

--- a/src/components/CalendarBooking/CalendarBooking.tsx
+++ b/src/components/CalendarBooking/CalendarBooking.tsx
@@ -4,6 +4,10 @@ import Button from '@mui/material/Button';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import CircularProgress from '@mui/material/CircularProgress';
+import Dialog from '@mui/material/Dialog';
+import Chip from '@mui/material/Chip';
+import Link from '@mui/material/Link';
+import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTheme } from '@mui/material/styles';
 import type { CalendarBookingProps, BookingFormData } from './CalendarBooking.types';
 
@@ -21,6 +25,10 @@ const TIME_SLOTS = [
 ] as const;
 
 const GRID_HEIGHT = ROW_HEIGHT * TIME_SLOTS.length;
+
+// Wall-clock minutes-of-day of the last bookable slot start (5:30 PM)
+const LAST_SLOT_MINUTES =
+  TIME_SLOTS[TIME_SLOTS.length - 1].hour * 60 + TIME_SLOTS[TIME_SLOTS.length - 1].minute;
 
 // Slot instants from the API are pinned to the business timezone; map them to
 // grid rows in that zone so visitors in any timezone see the same grid.
@@ -46,37 +54,134 @@ function slotRowForIso(iso: string, dateStr: string): number {
   return TIME_SLOTS.findIndex(s => s.hour === hour && s.minute === minute);
 }
 
-const WEEK_DAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
-
 const MONTH_NAMES = [
   'January', 'February', 'March', 'April', 'May', 'June',
   'July', 'August', 'September', 'October', 'November', 'December',
 ];
 
-// ── Helpers ──────────────────────────────────────────────────────────────────
+const WEEKDAY_SHORT = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+// ── Availability cache (sessionStorage, 30-min TTL) ───────────────────────────
+// Persists across client-side navigation and tab reloads so returning to the
+// page within the TTL does not re-query availability.
+
+const CACHE_TTL_MS = 30 * 60 * 1000;
+const CACHE_PREFIX = 'sui-availability:';
+
+function readSlotCache(date: string): string[] | null {
+  if (typeof window === 'undefined') {return null;}
+  try {
+    const raw = window.sessionStorage.getItem(CACHE_PREFIX + date);
+    if (!raw) {return null;}
+    const { slots, ts } = JSON.parse(raw) as { slots: string[]; ts: number };
+    if (Date.now() - ts > CACHE_TTL_MS) {return null;}
+    return Array.isArray(slots) ? slots : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeSlotCache(date: string, slots: string[]): void {
+  if (typeof window === 'undefined') {return;}
+  try {
+    window.sessionStorage.setItem(CACHE_PREFIX + date, JSON.stringify({ slots, ts: Date.now() }));
+  } catch {
+    /* storage full / unavailable — non-fatal */
+  }
+}
+
+// ── Date helpers (string-based, tz-stable) ────────────────────────────────────
 
 function toDateStr(d: Date): string {
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
 }
 
-function getMonday(d: Date): Date {
-  const date = new Date(d);
-  const dow = date.getDay();
-  date.setDate(date.getDate() - dow + (dow === 0 ? -6 : 1));
-  date.setHours(0, 0, 0, 0);
-  return date;
+// Day-of-week (0=Sun … 6=Sat) for a YYYY-MM-DD string, independent of timezone
+function dowOfDateStr(s: string): number {
+  const [y, m, d] = s.split('-').map(Number);
+  return new Date(Date.UTC(y, m - 1, d)).getUTCDay();
 }
 
-function addDays(d: Date, n: number): Date {
-  const date = new Date(d);
-  date.setDate(date.getDate() + n);
-  return date;
+function isWeekendStr(s: string): boolean {
+  const dow = dowOfDateStr(s);
+  return dow === 0 || dow === 6;
+}
+
+function addDaysStr(s: string, n: number): string {
+  const [y, m, d] = s.split('-').map(Number);
+  const dt = new Date(y, m - 1, d);
+  dt.setDate(dt.getDate() + n);
+  return toDateStr(dt);
+}
+
+// Next business-day date string at or after `s`
+function nextBusinessDateStr(s: string): string {
+  let cur = s;
+  while (isWeekendStr(cur)) {cur = addDaysStr(cur, 1);}
+  return cur;
+}
+
+// Today's calendar date (YYYY-MM-DD) in the business timezone
+function businessTodayStr(now: Date = new Date()): string {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: BUSINESS_TIMEZONE,
+    year: 'numeric', month: '2-digit', day: '2-digit',
+  }).format(now);
+}
+
+// Current minutes-of-day in the business timezone
+function businessNowMinutes(now: Date = new Date()): number {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: BUSINESS_TIMEZONE, hour12: false, hour: '2-digit', minute: '2-digit',
+  }).formatToParts(now);
+  const get = (t: string) => Number(parts.find(p => p.type === t)?.value);
+  return (get('hour') % 24) * 60 + get('minute');
+}
+
+// The first date that still has bookable slots: today if it is a weekday and
+// the last slot of the day has not yet started, otherwise the next weekday.
+function firstAvailableDateStr(now: Date = new Date()): string {
+  const today = businessTodayStr(now);
+  if (!isWeekendStr(today) && businessNowMinutes(now) < LAST_SLOT_MINUTES) {
+    return today;
+  }
+  return nextBusinessDateStr(addDaysStr(today, 1));
+}
+
+// 5 consecutive business-day date strings starting at `startStr` (weekends skipped)
+function buildWindowDates(startStr: string): string[] {
+  let cur = nextBusinessDateStr(startStr);
+  const out: string[] = [];
+  while (out.length < 5) {
+    out.push(cur);
+    cur = nextBusinessDateStr(addDaysStr(cur, 1));
+  }
+  return out;
 }
 
 function formatTimeLabel(hour: number, minute: number): string {
   const suffix = hour < 12 ? 'AM' : 'PM';
   const h = hour % 12 === 0 ? 12 : hour % 12;
   return `${h}:${String(minute).padStart(2, '0')} ${suffix}`;
+}
+
+function formatTimeFromMinutes(totalMinutes: number): string {
+  const h = Math.floor(totalMinutes / 60) % 24;
+  const m = totalMinutes % 60;
+  return formatTimeLabel(h, m);
+}
+
+// "Tuesday, June 16" for a YYYY-MM-DD string
+function formatLongDate(dateStr: string): string {
+  const [y, m, d] = dateStr.split('-').map(Number);
+  const dt = new Date(y, m - 1, d, 12);
+  return new Intl.DateTimeFormat('en-US', {
+    weekday: 'long', month: 'long', day: 'numeric',
+  }).format(dt);
+}
+
+function isValidEmail(s: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(s.trim());
 }
 
 // ── MiniCalendar ─────────────────────────────────────────────────────────────
@@ -94,7 +199,8 @@ function MiniCalendar({ year, month, selectedDate, onDateClick, onPrevMonth, onN
   const theme = useTheme();
   const firstDay = new Date(year, month, 1);
   const lastDay = new Date(year, month + 1, 0);
-  const startDow = (firstDay.getDay() + 6) % 7;
+  // Sunday-start weeks
+  const startDow = firstDay.getDay();
 
   const cells: { dateStr: string; dayNum: number; current: boolean }[] = [];
   for (let i = startDow - 1; i >= 0; i--) {
@@ -109,6 +215,9 @@ function MiniCalendar({ year, month, selectedDate, onDateClick, onPrevMonth, onN
     cells.push({ dateStr: toDateStr(new Date(year, month + 1, d)), dayNum: d, current: false });
   }
 
+  const dark = theme.palette.mode === 'dark';
+  const weekendBg = dark ? 'rgba(255,255,255,0.05)' : 'rgba(0,0,0,0.035)';
+
   const btnSx = {
     background: 'none', border: 'none', cursor: 'pointer',
     color: theme.palette.text.primary, fontSize: 16, lineHeight: 1,
@@ -117,36 +226,62 @@ function MiniCalendar({ year, month, selectedDate, onDateClick, onPrevMonth, onN
   } as const;
 
   return (
-    <Box data-testid="mini-calendar" sx={{ marginTop: 20, width: 220, flexShrink: 0, userSelect: 'none' }}>
+    <Box
+      data-testid="mini-calendar"
+      sx={{ marginTop: { xs: 0, sm: '20px' }, width: 240, maxWidth: '100%', flexShrink: 0, userSelect: 'none', mx: { xs: 'auto', sm: 0 } }}
+    >
       <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1 }}>
-        <Box component="button" onClick={onPrevMonth} sx={btnSx}>‹</Box>
+        <Box component="button" aria-label="Previous month" onClick={onPrevMonth} sx={btnSx}>‹</Box>
         <Typography variant="caption" sx={{ fontWeight: 700 }}>
           {MONTH_NAMES[month]} {year}
         </Typography>
-        <Box component="button" onClick={onNextMonth} sx={btnSx}>›</Box>
+        <Box component="button" aria-label="Next month" onClick={onNextMonth} sx={btnSx}>›</Box>
       </Box>
       <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', mb: 0.5 }}>
-        {['M', 'T', 'W', 'T', 'F', 'S', 'S'].map((d, i) => (
-          <Typography key={i} variant="caption" sx={{ textAlign: 'center', color: 'text.secondary', fontWeight: 600, fontSize: 10 }}>
+        {['S', 'M', 'T', 'W', 'T', 'F', 'S'].map((d, i) => (
+          <Typography
+            key={i}
+            variant="caption"
+            sx={{
+              textAlign: 'center', fontWeight: 600, fontSize: 10,
+              color: (i === 0 || i === 6) ? 'text.primary' : 'text.secondary',
+              backgroundColor: (i === 0 || i === 6) ? weekendBg : 'transparent',
+              borderRadius: '4px 4px 0 0',
+            }}
+          >
             {d}
           </Typography>
         ))}
       </Box>
-      <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', gap: '2px' }}>
-        {cells.map((cell) => {
+      <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)' }}>
+        {cells.map((cell, idx) => {
           const sel = selectedDate === cell.dateStr;
+          const col = idx % 7;
+          const weekend = col === 0 || col === 6;
           return (
             <Box
               key={cell.dateStr}
+              data-testid="mini-cal-cell"
+              data-weekend={weekend ? 'true' : 'false'}
+              data-selected={sel ? 'true' : 'false'}
               onClick={() => onDateClick(cell.dateStr)}
               sx={{
-                textAlign: 'center', cursor: 'pointer', py: '3px', borderRadius: '50%', fontSize: 11,
-                color: cell.current ? (sel ? 'primary.contrastText' : 'text.primary') : 'text.disabled',
-                backgroundColor: sel ? 'primary.main' : 'transparent',
-                '&:hover': { backgroundColor: sel ? 'primary.dark' : theme.palette.action.hover },
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
+                cursor: 'pointer', height: 28, fontSize: 11,
+                backgroundColor: weekend ? weekendBg : 'transparent',
               }}
             >
-              {cell.dayNum}
+              <Box
+                sx={{
+                  display: 'flex', alignItems: 'center', justifyContent: 'center',
+                  width: 24, height: 24, borderRadius: '50%',
+                  color: cell.current ? (sel ? 'primary.contrastText' : 'text.primary') : 'text.disabled',
+                  backgroundColor: sel ? 'primary.main' : 'transparent',
+                  '&:hover': { backgroundColor: sel ? 'primary.dark' : theme.palette.action.hover },
+                }}
+              >
+                {cell.dayNum}
+              </Box>
             </Box>
           );
         })}
@@ -167,23 +302,26 @@ interface DayState {
 
 export default function CalendarBooking({ apiBaseUrl = '', onSuccess, onError }: CalendarBookingProps) {
   const theme = useTheme();
+  const fullScreenModal = useMediaQuery(theme.breakpoints.down('sm'));
 
-  const todayRef = useRef<Date | null>(null);
-  if (!todayRef.current) {
-    const d = new Date(); d.setHours(0, 0, 0, 0);
-    todayRef.current = d;
+  const initialRef = useRef<{ today: string; windowStart: string } | null>(null);
+  if (!initialRef.current) {
+    const today = businessTodayStr();
+    initialRef.current = { today, windowStart: firstAvailableDateStr() };
   }
-  const today = todayRef.current;
+  const todayStr = initialRef.current.today;
 
-  const [calYear, setCalYear] = useState(today.getFullYear());
-  const [calMonth, setCalMonth] = useState(today.getMonth());
-  const [selectedDate, setSelectedDate] = useState<string | null>(null);
-  const [weekStart, setWeekStart] = useState<Date>(() => getMonday(today));
+  const [calYear, setCalYear] = useState(() => Number(todayStr.slice(0, 4)));
+  const [calMonth, setCalMonth] = useState(() => Number(todayStr.slice(5, 7)) - 1);
+  const [selectedDate, setSelectedDate] = useState<string | null>(todayStr);
+  const [windowStart, setWindowStart] = useState<string>(initialRef.current.windowStart);
   const [days, setDays] = useState<DayState[]>([]);
   const [selectedDay, setSelectedDay] = useState<string | null>(null);
   const [selectedTimeIndex, setSelectedTimeIndex] = useState(-1);
   const [duration, setDuration] = useState(30);
   const [formData, setFormData] = useState<BookingFormData>({ name: '', email: '', phone: '', company: '', reason: '' });
+  const [inviteEmails, setInviteEmails] = useState<string[]>([]);
+  const [inviteInput, setInviteInput] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [submitSuccess, setSubmitSuccess] = useState(false);
   const [submitError, setSubmitError] = useState('');
@@ -191,21 +329,37 @@ export default function CalendarBooking({ apiBaseUrl = '', onSuccess, onError }:
   const dragStartY = useRef<number | null>(null);
   const dragStartDuration = useRef(30);
 
-  function buildWeekDays(ws: Date): DayState[] {
-    return Array.from({ length: 5 }, (_, i) => {
-      const date = addDays(ws, i);
-      return { date: toDateStr(date), dayName: WEEK_DAYS[i], dayNum: date.getDate(), slotIsoByRow: new Map(), loading: date >= today };
-    });
+  function buildWeekDays(startStr: string): DayState[] {
+    return buildWindowDates(startStr).map((dateStr) => ({
+      date: dateStr,
+      dayName: WEEKDAY_SHORT[dowOfDateStr(dateStr)],
+      dayNum: Number(dateStr.slice(8, 10)),
+      slotIsoByRow: new Map(),
+      loading: dateStr >= todayStr,
+    }));
   }
 
   async function fetchDay(day: DayState): Promise<DayState> {
     if (!day.loading) {return day;} // past — skip
+
+    const cached = readSlotCache(day.date);
+    if (cached) {
+      const slotIsoByRow = new Map<number, string>();
+      for (const iso of cached) {
+        const row = slotRowForIso(iso, day.date);
+        if (row >= 0) {slotIsoByRow.set(row, iso);}
+      }
+      return { ...day, loading: false, slotIsoByRow };
+    }
+
     try {
       const res = await fetch(`${apiBaseUrl}/api/calendar/availability?date=${day.date}`);
       if (!res.ok) {return { ...day, loading: false };}
       const data = await res.json();
+      const slots = (data.slots || []) as string[];
+      writeSlotCache(day.date, slots);
       const slotIsoByRow = new Map<number, string>();
-      for (const iso of (data.slots || []) as string[]) {
+      for (const iso of slots) {
         const row = slotRowForIso(iso, day.date);
         if (row >= 0) {slotIsoByRow.set(row, iso);}
       }
@@ -216,14 +370,14 @@ export default function CalendarBooking({ apiBaseUrl = '', onSuccess, onError }:
   }
 
   useEffect(() => {
-    const initial = buildWeekDays(weekStart);
+    const initial = buildWeekDays(windowStart);
     setDays(initial);
     setSelectedDay(null);
     setSelectedTimeIndex(-1);
     setDuration(30);
     Promise.all(initial.map(fetchDay)).then(setDays);
-     
-  }, [weekStart, apiBaseUrl]);
+
+  }, [windowStart, apiBaseUrl]);
 
   function isAvailable(day: DayState, idx: number): boolean {
     const iso = day.slotIsoByRow.get(idx);
@@ -231,14 +385,12 @@ export default function CalendarBooking({ apiBaseUrl = '', onSuccess, onError }:
   }
 
   function isPastDay(day: DayState): boolean {
-    const [y, m, d] = day.date.split('-').map(Number);
-    return new Date(y, m - 1, d) < today;
+    return day.date < todayStr;
   }
 
   const handleDateClick = (dateStr: string) => {
     setSelectedDate(dateStr);
-    const [y, m, d] = dateStr.split('-').map(Number);
-    setWeekStart(getMonday(new Date(y, m - 1, d)));
+    setWindowStart(dateStr);
   };
 
   const handleSlotClick = (dayDate: string, timeIndex: number) => {
@@ -247,6 +399,12 @@ export default function CalendarBooking({ apiBaseUrl = '', onSuccess, onError }:
     setDuration(30);
     setSubmitError('');
     setSubmitSuccess(false);
+  };
+
+  const closeModal = () => {
+    setSelectedDay(null);
+    setSelectedTimeIndex(-1);
+    setSubmitError('');
   };
 
   const handleDragMouseDown = (e: React.MouseEvent) => {
@@ -272,7 +430,27 @@ export default function CalendarBooking({ apiBaseUrl = '', onSuccess, onError }:
     setFormData(prev => ({ ...prev, [name]: value }));
   };
 
-  const isSubmitEnabled = !!(formData.name && formData.email && formData.phone && selectedDay && selectedTimeIndex >= 0);
+  const commitInvite = () => {
+    const candidate = inviteInput.trim().replace(/[,;]$/, '').trim();
+    if (candidate && isValidEmail(candidate) && !inviteEmails.includes(candidate)) {
+      setInviteEmails(prev => [...prev, candidate]);
+      setInviteInput('');
+    }
+  };
+
+  const handleInviteKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ',' || e.key === ';') {
+      e.preventDefault();
+      commitInvite();
+    } else if (e.key === 'Backspace' && !inviteInput && inviteEmails.length) {
+      setInviteEmails(prev => prev.slice(0, -1));
+    }
+  };
+
+  const isSubmitEnabled = !!(
+    formData.name && formData.email && formData.phone && formData.reason &&
+    selectedDay && selectedTimeIndex >= 0
+  );
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -289,6 +467,7 @@ export default function CalendarBooking({ apiBaseUrl = '', onSuccess, onError }:
           ...formData,
           startTime,
           durationMinutes: duration,
+          inviteEmails,
         }),
       });
       const data = await res.json();
@@ -297,6 +476,8 @@ export default function CalendarBooking({ apiBaseUrl = '', onSuccess, onError }:
       setSelectedDay(null);
       setSelectedTimeIndex(-1);
       setFormData({ name: '', email: '', phone: '', company: '', reason: '' });
+      setInviteEmails([]);
+      setInviteInput('');
       setDuration(30);
       onSuccess?.(data.eventId, data.eventLink);
     } catch (err) {
@@ -314,9 +495,22 @@ export default function CalendarBooking({ apiBaseUrl = '', onSuccess, onError }:
   const durationRows = duration / 30; // may be fractional (45 min = 1.5)
   const blockHeight = Math.max(ROW_HEIGHT, durationRows * ROW_HEIGHT);
 
+  const modalOpen = !!selectedDay && selectedTimeIndex >= 0 && !submitSuccess;
+  const startMinutes = selectedTimeIndex >= 0
+    ? TIME_SLOTS[selectedTimeIndex].hour * 60 + TIME_SLOTS[selectedTimeIndex].minute
+    : 0;
+
   return (
     <Box sx={{ width: '100%', maxWidth: 1000, mx: 'auto' }}>
-      <Box sx={{ display: 'flex', gap: 7, flexWrap: 'wrap', alignItems: 'flex-start' }}>
+      <Box
+        sx={{
+          display: 'flex',
+          gap: { xs: 3, md: 7 },
+          flexWrap: 'wrap',
+          alignItems: 'flex-start',
+          flexDirection: { xs: 'column', sm: 'row' },
+        }}
+      >
         {/* Left: mini calendar */}
         <MiniCalendar
           year={calYear} month={calMonth}
@@ -325,146 +519,148 @@ export default function CalendarBooking({ apiBaseUrl = '', onSuccess, onError }:
           onPrevMonth={prevMonth} onNextMonth={nextMonth}
         />
 
-        {/* Right: week grid */}
-        <Box data-testid="week-grid" sx={{ flex: 1, minWidth: 0, overflow: 'hidden' }}>
-          {/* Day headers */}
-          <Box sx={{ display: 'grid', gridTemplateColumns: '56px repeat(5, 1fr)', mb: 0.5 }}>
-            <Box /> {/* time label spacer */}
-            {days.map(day => (
-              <Box
-                key={day.date}
-                data-testid="day-column-header"
-                sx={{ textAlign: 'center', py: 0.75 }}
-              >
-                <Typography variant="caption" display="block" sx={{ fontWeight: 600, color: 'text.secondary', fontSize: 10 }}>
-                  {day.dayName}
-                </Typography>
-                <Typography variant="body2" sx={{ fontWeight: 700, fontSize: 13 }}>
-                  {day.dayNum}
-                </Typography>
-              </Box>
-            ))}
-          </Box>
-
-          {/* Time grid body */}
-          <Box sx={{ display: 'grid', gridTemplateColumns: '56px repeat(5, 1fr)' }}>
-            {/* Left time label column */}
-            <Box sx={{ position: 'relative', height: GRID_HEIGHT }}>
-              {TIME_SLOTS.map((slot, i) => (
+        {/* Right: week grid (horizontally scrollable on small screens) */}
+        <Box sx={{ flex: 1, minWidth: 0, width: '100%', overflowX: 'auto' }}>
+          <Box data-testid="week-grid" sx={{ minWidth: 320 }}>
+            {/* Day headers */}
+            <Box sx={{ display: 'grid', gridTemplateColumns: '48px repeat(5, minmax(44px, 1fr))', mb: 0.5 }}>
+              <Box /> {/* time label spacer */}
+              {days.map(day => (
                 <Box
-                  key={i}
-                  sx={{
-                    position: 'absolute', top: i * ROW_HEIGHT, height: ROW_HEIGHT,
-                    width: '100%', display: 'flex', alignItems: 'center', pr: '8px',
-                  }}
+                  key={day.date}
+                  data-testid="day-column-header"
+                  sx={{ textAlign: 'center', py: 0.75 }}
                 >
-                  <Typography variant="caption" sx={{ fontSize: 9, color: 'text.disabled', lineHeight: 1, whiteSpace: 'nowrap' }}>
-                    {formatTimeLabel(slot.hour, slot.minute)}
+                  <Typography variant="caption" display="block" sx={{ fontWeight: 600, color: 'text.secondary', fontSize: 10 }}>
+                    {day.dayName}
+                  </Typography>
+                  <Typography variant="body2" sx={{ fontWeight: 700, fontSize: 13 }}>
+                    {day.dayNum}
                   </Typography>
                 </Box>
               ))}
             </Box>
 
-            {/* Day columns */}
-            {days.map(day => {
-              const past = isPastDay(day);
-              const isSelected = selectedDay === day.date;
-              const isToday = day.date === toDateStr(today);
-              const dark = theme.palette.mode === 'dark';
-              return (
-                <Box key={day.date} data-day-column={day.date} sx={{ position: 'relative', height: GRID_HEIGHT }}>
-                  {/* Background rows */}
-                  {TIME_SLOTS.map((_, i) => {
-                    const avail = !past && isAvailable(day, i);
-                    const rowSelected = isSelected && i === selectedTimeIndex;
-                    return (
+            {/* Time grid body */}
+            <Box sx={{ display: 'grid', gridTemplateColumns: '48px repeat(5, minmax(44px, 1fr))' }}>
+              {/* Left time label column */}
+              <Box sx={{ position: 'relative', height: GRID_HEIGHT }}>
+                {TIME_SLOTS.map((slot, i) => (
+                  <Box
+                    key={i}
+                    sx={{
+                      position: 'absolute', top: i * ROW_HEIGHT, height: ROW_HEIGHT,
+                      width: '100%', display: 'flex', alignItems: 'center', pr: '8px',
+                    }}
+                  >
+                    <Typography variant="caption" sx={{ fontSize: 9, color: 'text.disabled', lineHeight: 1, whiteSpace: 'nowrap' }}>
+                      {formatTimeLabel(slot.hour, slot.minute)}
+                    </Typography>
+                  </Box>
+                ))}
+              </Box>
+
+              {/* Day columns */}
+              {days.map(day => {
+                const past = isPastDay(day);
+                const isSelected = selectedDay === day.date;
+                const isToday = day.date === todayStr;
+                const dark = theme.palette.mode === 'dark';
+                return (
+                  <Box key={day.date} data-day-column={day.date} sx={{ position: 'relative', height: GRID_HEIGHT }}>
+                    {/* Background rows */}
+                    {TIME_SLOTS.map((_, i) => {
+                      const avail = !past && isAvailable(day, i);
+                      const rowSelected = isSelected && i === selectedTimeIndex;
+                      return (
+                        <Box
+                          key={i}
+                          data-testid={avail ? 'time-slot' : 'day-unavailable'}
+                          data-selected={rowSelected ? 'true' : 'false'}
+                          data-today={isToday ? 'true' : 'false'}
+                          onClick={avail ? () => handleSlotClick(day.date, i) : undefined}
+                          sx={{
+                            position: 'absolute', top: i * ROW_HEIGHT + 2, height: ROW_HEIGHT - 5,
+                            left: 3, right: 3,
+                            borderRadius: '6px',
+                            display: 'flex', alignItems: 'center', justifyContent: 'center',
+                            cursor: avail ? 'pointer' : 'default',
+                            backgroundColor: avail
+                              ? (dark
+                                ? (isToday ? 'rgba(255,255,255,0.11)' : 'rgba(255,255,255,0.07)')
+                                : (isToday ? 'rgba(0,0,0,0.10)' : 'rgba(0,0,0,0.06)'))
+                              : (dark
+                                ? (isToday ? 'rgba(255,255,255,0.06)' : 'rgba(255,255,255,0.03)')
+                                : (isToday ? 'rgba(0,0,0,0.05)' : 'rgba(0,0,0,0.025)')),
+                            '&:hover': avail ? { backgroundColor: dark ? 'rgba(255,255,255,0.16)' : 'rgba(0,0,0,0.13)' } : {},
+                          }}
+                        >
+                          {!avail && (
+                            <Typography component="span" sx={{ fontSize: 11, lineHeight: 1, color: dark ? 'rgba(255,255,255,0.18)' : 'rgba(0,0,0,0.2)', userSelect: 'none' }}>
+                              —
+                            </Typography>
+                          )}
+                        </Box>
+                      );
+                    })}
+
+                    {/* Loading overlay */}
+                    {day.loading && (
+                      <Box sx={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                        <CircularProgress size={14} />
+                      </Box>
+                    )}
+
+                    {/* Selected event block */}
+                    {isSelected && selectedTimeIndex >= 0 && (
                       <Box
-                        key={i}
-                        data-testid={avail ? 'time-slot' : 'day-unavailable'}
-                        data-selected={rowSelected ? 'true' : 'false'}
-                        data-today={isToday ? 'true' : 'false'}
-                        onClick={avail ? () => handleSlotClick(day.date, i) : undefined}
                         sx={{
-                          position: 'absolute', top: i * ROW_HEIGHT + 2, height: ROW_HEIGHT - 5,
-                          left: 3, right: 3,
-                          borderRadius: '6px',
-                          display: 'flex', alignItems: 'center', justifyContent: 'center',
-                          cursor: avail ? 'pointer' : 'default',
-                          backgroundColor: avail
-                            ? (dark
-                              ? (isToday ? 'rgba(255,255,255,0.11)' : 'rgba(255,255,255,0.07)')
-                              : (isToday ? 'rgba(0,0,0,0.10)' : 'rgba(0,0,0,0.06)'))
-                            : (dark
-                              ? (isToday ? 'rgba(255,255,255,0.06)' : 'rgba(255,255,255,0.03)')
-                              : (isToday ? 'rgba(0,0,0,0.05)' : 'rgba(0,0,0,0.025)')),
-                          '&:hover': avail ? { backgroundColor: dark ? 'rgba(255,255,255,0.16)' : 'rgba(0,0,0,0.13)' } : {},
+                          position: 'absolute',
+                          top: selectedTimeIndex * ROW_HEIGHT,
+                          height: blockHeight,
+                          left: 2, right: 2,
+                          backgroundColor: 'primary.main',
+                          borderRadius: '4px 4px 0 0',
+                          zIndex: 2,
+                          overflow: 'hidden',
+                          pointerEvents: 'none',
                         }}
                       >
-                        {!avail && (
-                          <Typography component="span" sx={{ fontSize: 11, lineHeight: 1, color: dark ? 'rgba(255,255,255,0.18)' : 'rgba(0,0,0,0.2)', userSelect: 'none' }}>
-                            —
-                          </Typography>
-                        )}
+                        <Typography variant="caption" sx={{ display: 'block', color: 'primary.contrastText', px: 0.5, pt: '2px', fontSize: 10, lineHeight: 1.2 }}>
+                          {formatTimeLabel(TIME_SLOTS[selectedTimeIndex].hour, TIME_SLOTS[selectedTimeIndex].minute)}
+                        </Typography>
+                        <Typography
+                          data-testid="duration-display"
+                          variant="caption"
+                          sx={{ display: 'block', color: 'primary.contrastText', px: 0.5, fontSize: 9, lineHeight: 1 }}
+                        >
+                          {duration} min
+                        </Typography>
                       </Box>
-                    );
-                  })}
+                    )}
 
-                  {/* Loading overlay */}
-                  {day.loading && (
-                    <Box sx={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                      <CircularProgress size={14} />
-                    </Box>
-                  )}
-
-                  {/* Selected event block */}
-                  {isSelected && selectedTimeIndex >= 0 && (
-                    <Box
-                      sx={{
-                        position: 'absolute',
-                        top: selectedTimeIndex * ROW_HEIGHT,
-                        height: blockHeight,
-                        left: 2, right: 2,
-                        backgroundColor: 'primary.main',
-                        borderRadius: '4px 4px 0 0',
-                        zIndex: 2,
-                        overflow: 'hidden',
-                        pointerEvents: 'none',
-                      }}
-                    >
-                      <Typography variant="caption" sx={{ display: 'block', color: 'primary.contrastText', px: 0.5, pt: '2px', fontSize: 10, lineHeight: 1.2 }}>
-                        {formatTimeLabel(TIME_SLOTS[selectedTimeIndex].hour, TIME_SLOTS[selectedTimeIndex].minute)}
-                      </Typography>
-                      <Typography
-                        data-testid="duration-display"
-                        variant="caption"
-                        sx={{ display: 'block', color: 'primary.contrastText', px: 0.5, fontSize: 9, lineHeight: 1 }}
-                      >
-                        {duration} min
-                      </Typography>
-                    </Box>
-                  )}
-
-                  {/* Drag handle — sits below the block, pointer-events enabled */}
-                  {isSelected && selectedTimeIndex >= 0 && (
-                    <Box
-                      data-testid="duration-drag-handle-bottom"
-                      onMouseDown={handleDragMouseDown}
-                      sx={{
-                        position: 'absolute',
-                        top: selectedTimeIndex * ROW_HEIGHT + blockHeight,
-                        left: 2, right: 2,
-                        height: 8,
-                        backgroundColor: 'primary.dark',
-                        borderRadius: '0 0 4px 4px',
-                        cursor: 'ns-resize',
-                        zIndex: 3,
-                        '&:hover': { opacity: 0.8 },
-                      }}
-                    />
-                  )}
-                </Box>
-              );
-            })}
+                    {/* Drag handle — sits below the block, pointer-events enabled */}
+                    {isSelected && selectedTimeIndex >= 0 && (
+                      <Box
+                        data-testid="duration-drag-handle-bottom"
+                        onMouseDown={handleDragMouseDown}
+                        sx={{
+                          position: 'absolute',
+                          top: selectedTimeIndex * ROW_HEIGHT + blockHeight,
+                          left: 2, right: 2,
+                          height: 8,
+                          backgroundColor: 'primary.dark',
+                          borderRadius: '0 0 4px 4px',
+                          cursor: 'ns-resize',
+                          zIndex: 3,
+                          '&:hover': { opacity: 0.8 },
+                        }}
+                      />
+                    )}
+                  </Box>
+                );
+              })}
+            </Box>
           </Box>
         </Box>
       </Box>
@@ -476,38 +672,112 @@ export default function CalendarBooking({ apiBaseUrl = '', onSuccess, onError }:
         </Box>
       )}
 
-      {/* Booking form */}
-      {selectedDay && selectedTimeIndex >= 0 && !submitSuccess && (
-        <Box
-          component="form"
-          data-testid="booking-form"
-          onSubmit={handleSubmit}
-          sx={{ mt: 3, p: 3, borderRadius: 2, border: '1px solid', borderColor: 'divider', backgroundColor: theme.palette.mode === 'dark' ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.02)' }}
-        >
-          <Typography variant="h6" sx={{ mb: 2, fontWeight: 600 }}>
-            {formatTimeLabel(TIME_SLOTS[selectedTimeIndex].hour, TIME_SLOTS[selectedTimeIndex].minute)} — {selectedDay}
-          </Typography>
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-            <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 2 }}>
-              <TextField fullWidth label="Name" name="name" value={formData.name} onChange={handleFormChange} size="small" required disabled={submitting} />
-              <TextField fullWidth label="Email" name="email" type="email" value={formData.email} onChange={handleFormChange} size="small" required disabled={submitting} />
-            </Box>
-            <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 2 }}>
-              <TextField fullWidth label="Phone" name="phone" value={formData.phone} onChange={handleFormChange} size="small" required disabled={submitting} />
-              <TextField fullWidth label="Company" name="company" value={formData.company} onChange={handleFormChange} size="small" disabled={submitting} />
-            </Box>
-            <TextField fullWidth label="Reason" name="reason" value={formData.reason} onChange={handleFormChange} size="small" disabled={submitting} />
-            {submitError && (
-              <Box data-testid="booking-error" sx={{ p: 1.5, borderRadius: 1, backgroundColor: theme.palette.mode === 'dark' ? 'error.dark' : 'error.light', color: 'error.contrastText' }}>
-                <Typography variant="body2">{submitError}</Typography>
+      {/* Booking form modal */}
+      <Dialog
+        open={modalOpen}
+        onClose={closeModal}
+        fullScreen={fullScreenModal}
+        maxWidth="md"
+        fullWidth
+        PaperProps={{ sx: { borderRadius: fullScreenModal ? 0 : 3 } }}
+      >
+        {modalOpen && (
+          <Box
+            component="form"
+            data-testid="booking-form"
+            onSubmit={handleSubmit}
+            sx={{ p: { xs: 2.5, sm: 4 } }}
+          >
+            {/* Header */}
+            <Box sx={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 2 }}>
+              <Box>
+                <Typography variant="h6" sx={{ fontWeight: 800, fontSize: { xs: 18, sm: 22 }, lineHeight: 1.2 }}>
+                  {formatLongDate(selectedDay!)} · {formatTimeFromMinutes(startMinutes)} – {formatTimeFromMinutes(startMinutes + duration)}
+                </Typography>
+                <Typography variant="body2" sx={{ mt: 0.75, color: 'text.secondary' }}>
+                  {duration} Minutes · Google Meet
+                </Typography>
               </Box>
-            )}
-            <Button type="submit" variant="contained" size="large" disabled={!isSubmitEnabled || submitting}>
-              {submitting ? <CircularProgress size={20} color="inherit" /> : 'Book Appointment'}
-            </Button>
+              <Link
+                component="button"
+                type="button"
+                onClick={closeModal}
+                data-testid="change-time"
+                underline="hover"
+                sx={{ fontWeight: 700, whiteSpace: 'nowrap', flexShrink: 0, mt: 0.5 }}
+              >
+                Change time
+              </Link>
+            </Box>
+
+            <Box sx={{ height: '1px', backgroundColor: 'divider', my: 3 }} />
+
+            {/* Fields */}
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2.5 }}>
+              <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' }, gap: 2.5 }}>
+                <TextField fullWidth label="Name" name="name" value={formData.name} onChange={handleFormChange} placeholder="Your full name" size="medium" required disabled={submitting} />
+                <TextField fullWidth label="Email" name="email" type="email" value={formData.email} onChange={handleFormChange} placeholder="you@example.com" size="medium" required disabled={submitting} />
+              </Box>
+              <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' }, gap: 2.5 }}>
+                <TextField fullWidth label="Phone" name="phone" value={formData.phone} onChange={handleFormChange} placeholder="+1 (555) 000-0000" size="medium" required disabled={submitting} />
+                <TextField fullWidth label="Company" name="company" value={formData.company} onChange={handleFormChange} placeholder="Where do you work?" size="medium" disabled={submitting} />
+              </Box>
+              <TextField
+                fullWidth label="Reason" name="reason" value={formData.reason} onChange={handleFormChange}
+                placeholder="What would you like to discuss? Please be as specific as possible."
+                size="medium" required disabled={submitting}
+                multiline minRows={3}
+              />
+
+              {/* Invite others */}
+              <Box>
+                <Box
+                  sx={{
+                    display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 0.75,
+                    p: inviteEmails.length ? 1 : 0,
+                  }}
+                >
+                  {inviteEmails.map((em) => (
+                    <Chip
+                      key={em}
+                      label={em}
+                      size="small"
+                      onDelete={() => setInviteEmails(prev => prev.filter(x => x !== em))}
+                      disabled={submitting}
+                    />
+                  ))}
+                </Box>
+                <TextField
+                  fullWidth
+                  label="Invite others"
+                  value={inviteInput}
+                  onChange={(e) => setInviteInput(e.target.value)}
+                  onKeyDown={handleInviteKeyDown}
+                  onBlur={commitInvite}
+                  placeholder="Enter email and press Enter"
+                  size="medium"
+                  disabled={submitting}
+                  inputProps={{ 'data-testid': 'invite-input', type: 'email' }}
+                  helperText="Optional — invite colleagues or teammates to this meeting."
+                />
+              </Box>
+
+              {submitError && (
+                <Box data-testid="booking-error" sx={{ p: 1.5, borderRadius: 1, backgroundColor: theme.palette.mode === 'dark' ? 'error.dark' : 'error.light', color: 'error.contrastText' }}>
+                  <Typography variant="body2">{submitError}</Typography>
+                </Box>
+              )}
+
+              <Button type="submit" variant="contained" size="large" disabled={!isSubmitEnabled || submitting} sx={{ py: 1.5, borderRadius: 2, fontWeight: 700 }}>
+                {submitting ? <CircularProgress size={22} color="inherit" /> : 'Book Appointment'}
+              </Button>
+              <Typography variant="caption" sx={{ textAlign: 'center', color: 'text.secondary' }}>
+                You&apos;ll receive a confirmation email with a calendar invite.
+              </Typography>
+            </Box>
           </Box>
-        </Box>
-      )}
+        )}
+      </Dialog>
     </Box>
   );
 }

--- a/src/components/GithubEvents/GithubEvents.tsx
+++ b/src/components/GithubEvents/GithubEvents.tsx
@@ -105,7 +105,9 @@ export default function GithubEvents({ eventsPerPage = EVENT_PAGE_SIZE, hideMeta
   // Group events by repo for mobile repo strip - uses ALL repos from filters API
   // Sorted by most recent event, with accurate total counts from DB
   const mobileRepoGroups = React.useMemo(() => {
-    const groups = repositories.map(repoName => {
+    const groups = repositories
+      .filter((repoName): repoName is string => typeof repoName === 'string' && repoName.length > 0)
+      .map(repoName => {
       const shortName = repoName.split('/')[1] || repoName;
       const stats = repoStats[repoName];
       return {
@@ -763,7 +765,7 @@ export default function GithubEvents({ eventsPerPage = EVENT_PAGE_SIZE, hideMeta
   const filterEvents = (events: GitHubEvent[]) => {
     return events.filter(event => {
       // Compare just the repo name without username
-      const repoName = event.repo.name.split('/')[1] || event.repo.name;
+      const repoName = event.repo?.name ? (event.repo.name.split('/')[1] || event.repo.name) : '';
       const matchesRepo = !repoFilter || repoName === repoFilter;
       const matchesAction = !actionFilter || event.type.replace('Event', '') === actionFilter;
 
@@ -1554,7 +1556,7 @@ export default function GithubEvents({ eventsPerPage = EVENT_PAGE_SIZE, hideMeta
                                       {commit.sha.substring(0, 7)}
                                     </Typography>
                                     <Typography variant="body2" component="span" sx={{ fontSize: '0.8rem' }}>
-                                      {replaceGithubEmoji(commit.message.split('\n')[0])}
+                                      {replaceGithubEmoji(commit.message?.split('\n')[0] || '')}
                                     </Typography>
                                   </Box>
                                 </Box>
@@ -1656,7 +1658,7 @@ export default function GithubEvents({ eventsPerPage = EVENT_PAGE_SIZE, hideMeta
                         {/* Fallback for other event types */}
                         {!['PushEvent', 'PullRequestEvent', 'IssuesEvent', 'IssueCommentEvent', 'CreateEvent', 'DeleteEvent'].includes(event.actionType) && (
                           <Typography variant="body2" sx={{ fontSize: '0.85rem', color: 'text.primary' }}>
-                            {event.description || `${event.action} in ${event.repo.split('/')[1]}`}
+                            {event.description || `${event.action} in ${event.repo?.split('/')[1] ?? ''}`}
                           </Typography>
                         )}
                       </Box>
@@ -1787,7 +1789,7 @@ export default function GithubEvents({ eventsPerPage = EVENT_PAGE_SIZE, hideMeta
                           {getTimeOnly(event.date)}
                         </Box>
                         <Box sx={{ display: 'flex', alignItems: 'center', fontSize: '0.875rem', justifyContent: 'center' }}>
-                          {event.repo.split('/')[1]}
+                          {event.repo?.split('/')[1]}
                         </Box>
                         <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, height: '38px', fontSize: '0.875rem' }}>
                           {actionIcons[event.action] || null}

--- a/src/components/header/HeaderNavBar.tsx
+++ b/src/components/header/HeaderNavBar.tsx
@@ -2,10 +2,30 @@
 import * as React from 'react';
 import { styled, alpha } from '@mui/material/styles';
 import { unstable_debounce as debounce } from '@mui/utils';
+import { useRouter } from 'next/router';
 import ROUTES from 'src/route';
 import { PRODUCTS } from 'src/products';
 import NextLink from 'next/link';
 import List from "@mui/material/List";
+
+// Normalize a path for active-route comparison: drop origin, query, hash, and
+// any trailing slash. External (absolute) URLs return null and never match.
+function normalizePath(href: string): string | null {
+  if (/^https?:\/\//.test(href)) {return null;}
+  const path = href.split('?')[0].split('#')[0];
+  const trimmed = path.replace(/\/+$/, '');
+  return trimmed === '' ? '/' : trimmed;
+}
+
+const NAV_ITEMS: { href: string; label: string }[] = [
+  { href: ROUTES.work, label: 'Work' },
+  { href: ROUTES.art, label: 'Art' },
+  { href: ROUTES.photography, label: 'Photography' },
+  { href: ROUTES.drums, label: 'Drums' },
+  { href: ROUTES.resume, label: 'Resume' },
+  { href: ROUTES.plan, label: '.plan' },
+  { href: ROUTES.bookTime, label: 'Meet' },
+];
 
 const Navigation = styled('nav')(({ theme }) => [
   {
@@ -46,6 +66,11 @@ const Navigation = styled('nav')(({ theme }) => [
           outline: `3px solid ${alpha(theme.palette.primary[500], 0.5)}`,
           outlineOffset: '2px',
         },
+        '&[aria-current="page"]': {
+          color: theme.palette.primary[600],
+          backgroundColor: alpha(theme.palette.primary[500], 0.08),
+          borderColor: alpha(theme.palette.primary[500], 0.2),
+        },
       },
     },
   },
@@ -72,6 +97,11 @@ const Navigation = styled('nav')(({ theme }) => [
           backgroundColor: alpha(theme.palette.primaryDark[700], 0.8),
           borderColor: theme.palette.divider,
         },
+        '&[aria-current="page"]': {
+          color: theme.palette.primary[200],
+          backgroundColor: alpha(theme.palette.primaryDark[700], 0.8),
+          borderColor: theme.palette.divider,
+        },
       },
     },
   }),
@@ -82,6 +112,8 @@ const getProductIds = () => {
 }
 
 export default function HeaderNavBar() {
+  const router = useRouter();
+  const currentPath = normalizePath(router.asPath || '');
   const [subMenuOpen, setSubMenuOpen] = React.useState<null | 'products' | 'docs'>(null);
   const [subMenuIndex, setSubMenuIndex] = React.useState<number | null>(null);
   const navRef = React.useRef<HTMLUListElement | null>(null);
@@ -166,13 +198,17 @@ export default function HeaderNavBar() {
   return (
     <Navigation>
       <List sx={{}} ref={navRef} onKeyDown={handleKeyDown}>
-        <li><NextLink href={ROUTES.work}>Work</NextLink></li>
-        <li><NextLink href={ROUTES.art}>Art</NextLink></li>
-        <li><NextLink href={ROUTES.photography}>Photography</NextLink></li>
-        <li><NextLink href={ROUTES.drums}>Drums</NextLink></li>
-        <li><NextLink href={ROUTES.resume}>Resume</NextLink></li>
-        <li><NextLink href={ROUTES.plan}>.plan</NextLink></li>
-        <li><NextLink href={ROUTES.bookTime}>Book Time</NextLink></li>
+        {NAV_ITEMS.map((item) => {
+          const itemPath = normalizePath(item.href);
+          const active = itemPath !== null && itemPath === currentPath;
+          return (
+            <li key={item.href}>
+              <NextLink href={item.href} aria-current={active ? 'page' : undefined}>
+                {item.label}
+              </NextLink>
+            </li>
+          );
+        })}
       </List>
     </Navigation>);
 }

--- a/src/components/header/HeaderNavDropdown.tsx
+++ b/src/components/header/HeaderNavDropdown.tsx
@@ -12,9 +12,18 @@ import Typography from '@mui/material/Typography';
 import GitHubIcon from '@mui/icons-material/GitHub';
 import SvgHamburgerMenu from 'src/icons/SvgHamburgerMenu';
 import NextLink from 'next/link';
+import { useRouter } from 'next/router';
 import ROUTES from 'src/route';
 import ThemeModeToggle from './ThemeModeToggle';
 import IconImage from '../icon/IconImage';
+
+// Normalize a path for active-route comparison (origin/query/hash/trailing-slash agnostic)
+function normalizePath(href: string): string | null {
+  if (/^https?:\/\//.test(href)) {return null;}
+  const path = href.split('?')[0].split('#')[0];
+  const trimmed = path.replace(/\/+$/, '');
+  return trimmed === '' ? '/' : trimmed;
+}
 
 const StyledLink = styled(NextLink)(
   ({ theme }) => [
@@ -66,10 +75,12 @@ const navItems = [
   { href: ROUTES.drums, icon: 'icon-diamonds', label: 'Drums' },
   { href: ROUTES.resume, icon: 'icon-rect', label: 'Resume' },
   { href: ROUTES.plan, icon: 'icon-triangle', label: '.plan' },
-  { href: ROUTES.bookTime, icon: 'icon-hex', label: 'Book Time' },
+  { href: ROUTES.bookTime, icon: 'icon-hex', label: 'Meet' },
 ];
 
 export default function HeaderNavDropdown() {
+  const router = useRouter();
+  const currentPath = normalizePath(router.asPath || '');
   const [open, setOpen] = React.useState(false);
   const hambugerRef = React.useRef<HTMLButtonElement>(null);
   const menuId = React.useId();
@@ -82,22 +93,42 @@ export default function HeaderNavDropdown() {
         width: '100%',
         pr: 2,
       }}>
-        {navItems.map((item) => (
-          <Tooltip key={item.href} title={item.label} arrow>
-            <IconButton
-              component={NextLink}
-              href={item.href}
-              color="primary"
-              aria-label={item.label}
-              disableRipple
-              sx={{
-                position: 'relative',
-              }}
-            >
-              <IconImage name={item.icon} width={20} height={20} />
-            </IconButton>
-          </Tooltip>
-        ))}
+        {navItems.map((item) => {
+          const itemPath = normalizePath(item.href);
+          const active = itemPath !== null && itemPath === currentPath;
+          return (
+            <Tooltip key={item.href} title={item.label} arrow>
+              <IconButton
+                component={NextLink}
+                href={item.href}
+                color="primary"
+                aria-label={item.label}
+                aria-current={active ? 'page' : undefined}
+                disableRipple
+                sx={{
+                  position: 'relative',
+                  borderRadius: 1,
+                  ...(active && {
+                    backgroundColor: (theme) => alpha(theme.palette.primary.main, 0.12),
+                    '&::after': {
+                      content: '""',
+                      position: 'absolute',
+                      bottom: 2,
+                      left: '50%',
+                      transform: 'translateX(-50%)',
+                      width: 16,
+                      height: 2,
+                      borderRadius: 1,
+                      backgroundColor: 'primary.main',
+                    },
+                  }),
+                }}
+              >
+                <IconImage name={item.icon} width={20} height={20} />
+              </IconButton>
+            </Tooltip>
+          );
+        })}
       </Box>
     </React.Fragment>
   );


### PR DESCRIPTION
## Problem
brian.stokd.cloud / brianstoker.com crashed on load: **`TypeError: Cannot read properties of null (reading 'split')`**. `/api/github/filters` returned a `null` inside `repositories[]`, and the `mobileRepoGroups` `useMemo` did `repositories.map(r => r.split('/'))` with no guard — taking the whole page down via the React error boundary.

## Fix
- Filter null/empty repo names out of `mobileRepoGroups` (the crash site).
- Defensive optional-chaining on the sibling `event.repo` / `event.repo.name` / `commit.message` `.split()` render paths that consume the same data.
- Add `e2e/github-events-null-repo.spec.ts` (Playwright): mocks the filters API with a null repo, asserts no client crash on `/work`. **Verified red (2 crashes) before, green after.**

## Also included (pre-existing WIP)
- `/book-time` calendar booking flow + Google Calendar API
- Header nav link updates
- Removes a stray `=` artifact file

🤖 Generated with [Claude Code](https://claude.com/claude-code)